### PR TITLE
Restore the solution titles on the profile page

### DIFF
--- a/extension/styles.css
+++ b/extension/styles.css
@@ -108,6 +108,10 @@ div.header .h1-subtitle {
     margin-bottom: 0px !important;
 }
 
+#profile-page .solution .title {
+    font-size: 1.2rem !important
+}
+
 .solution .details .extra {
     color: #888 !important;
     color: var(--grey-700) !important;


### PR DESCRIPTION
<img width="962" alt="profile_page_missing_titles" src="https://user-images.githubusercontent.com/122470/78454907-0d007980-7669-11ea-8653-328a4afcb89a.png">

I hope this wan't intentional: I certainly don't want to memorize 100+ icons.